### PR TITLE
Update `airtable` to latest version, v0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/victorhahn/airtable-plus#readme",
   "dependencies": {
-    "airtable": "^0.7.1",
+    "airtable": "^0.7.2",
     "camelcase-keys": "^5.0.0",
     "p-map": "^2.0.0"
   },


### PR DESCRIPTION
This updates `airtable` to the latest version, v0.7.2. [See the changelog][1] for more info on what changed.

I didn't update the version number because I wasn't sure about your release process, but let me know if you want me to update that.

[1]: https://github.com/Airtable/airtable.js/blob/v0.7.2/CHANGELOG.md